### PR TITLE
Add pagination buttons for SubTurtle backlog/logs in Telegram

### DIFF
--- a/super_turtle/claude-telegram-bot/src/handlers/callback.subturtle.test.ts
+++ b/super_turtle/claude-telegram-bot/src/handlers/callback.subturtle.test.ts
@@ -113,6 +113,143 @@ describe("subturtle callback actions", () => {
   });
 });
 
+describe("backlog pagination", () => {
+  it("shows first page of backlog with Next button", async () => {
+    const turtleName = "backlog-test";
+    const turtleDir = join(WORKING_DIR, ".subturtles", turtleName);
+    mkdirSync(turtleDir, { recursive: true });
+
+    // Create a backlog with 8 items (more than one page of 5)
+    const items = Array.from({ length: 8 }, (_, i) =>
+      i < 3 ? `- [x] Done item ${i + 1}` : `- [ ] Todo item ${i + 1}`
+    );
+    writeFileSync(
+      join(turtleDir, "CLAUDE.md"),
+      ["## Current Task", "Working on stuff.", "", "## Backlog", ...items].join("\n")
+    );
+
+    const { ctx, callbackAnswers, edits } = makeCallbackCtx(`sub_bl:${turtleName}:0`);
+
+    try {
+      await handleCallback(ctx);
+    } finally {
+      rmSync(turtleDir, { recursive: true, force: true });
+    }
+
+    expect(callbackAnswers).toEqual([""]);
+    expect(edits).toHaveLength(1);
+    const text = edits[0]!.text;
+    expect(text).toContain(`Backlog for ${turtleName}`);
+    expect(text).toContain("3/8 done");
+    expect(text).toContain("page 1/2");
+    expect(text).toContain("Done item 1");
+    expect(text).toContain("Todo item 5");
+    // Should NOT contain items from page 2
+    expect(text).not.toContain("Todo item 6");
+
+    // Should have a Next button but no Prev button, plus a Menu button
+    const keyboard = (edits[0]!.extra as any)?.reply_markup?.inline_keyboard;
+    expect(keyboard).toHaveLength(2);
+    expect(keyboard[0].some((b: any) => b.text === "▶ Next")).toBe(true);
+    expect(keyboard[0].some((b: any) => b.text === "◀ Prev")).toBe(false);
+    expect(keyboard[1].some((b: any) => b.text === "↩ Menu")).toBe(true);
+  });
+
+  it("shows second page with Prev button", async () => {
+    const turtleName = "backlog-page2";
+    const turtleDir = join(WORKING_DIR, ".subturtles", turtleName);
+    mkdirSync(turtleDir, { recursive: true });
+
+    const items = Array.from({ length: 8 }, (_, i) => `- [ ] Item ${i + 1}`);
+    writeFileSync(
+      join(turtleDir, "CLAUDE.md"),
+      ["## Current Task", "Working.", "", "## Backlog", ...items].join("\n")
+    );
+
+    const { ctx, callbackAnswers, edits } = makeCallbackCtx(`sub_bl:${turtleName}:1`);
+
+    try {
+      await handleCallback(ctx);
+    } finally {
+      rmSync(turtleDir, { recursive: true, force: true });
+    }
+
+    expect(edits).toHaveLength(1);
+    const text = edits[0]!.text;
+    expect(text).toContain("page 2/2");
+    expect(text).toContain("Item 6");
+    expect(text).not.toContain("Item 5");
+
+    const keyboard = (edits[0]!.extra as any)?.reply_markup?.inline_keyboard;
+    expect(keyboard[0].some((b: any) => b.text === "◀ Prev")).toBe(true);
+    expect(keyboard[0].some((b: any) => b.text === "▶ Next")).toBe(false);
+  });
+
+  it("returns toast when backlog is empty", async () => {
+    const turtleName = "backlog-empty";
+    const turtleDir = join(WORKING_DIR, ".subturtles", turtleName);
+    mkdirSync(turtleDir, { recursive: true });
+
+    writeFileSync(
+      join(turtleDir, "CLAUDE.md"),
+      ["## Current Task", "No backlog here."].join("\n")
+    );
+
+    const { ctx, callbackAnswers, edits } = makeCallbackCtx(`sub_bl:${turtleName}:0`);
+
+    try {
+      await handleCallback(ctx);
+    } finally {
+      rmSync(turtleDir, { recursive: true, force: true });
+    }
+
+    expect(callbackAnswers).toEqual(["No backlog items"]);
+    expect(edits).toHaveLength(0);
+  });
+});
+
+describe("log pagination", () => {
+  it("shows most recent log lines on page 0 with Older button", async () => {
+    const turtleName = "logs-test";
+    const turtleDir = join(WORKING_DIR, ".subturtles", turtleName);
+    mkdirSync(turtleDir, { recursive: true });
+
+    // Create 50 log lines (more than one page of 30)
+    const logLines = Array.from({ length: 50 }, (_, i) => `[2025-01-01] Log line ${i + 1}`);
+    writeFileSync(join(turtleDir, "subturtle.log"), logLines.join("\n"));
+
+    const { ctx, callbackAnswers, edits } = makeCallbackCtx(`sub_lg:${turtleName}:0`);
+
+    try {
+      await handleCallback(ctx);
+    } finally {
+      rmSync(turtleDir, { recursive: true, force: true });
+    }
+
+    expect(callbackAnswers).toEqual([""]);
+    expect(edits).toHaveLength(1);
+    const text = edits[0]!.text;
+    expect(text).toContain(`Logs for ${turtleName}`);
+    expect(text).toContain("page 1/2");
+    // Page 0 should show the newest lines (21-50)
+    expect(text).toContain("Log line 50");
+    expect(text).toContain("Log line 21");
+    expect(text).not.toContain("Log line 20");
+
+    const keyboard = (edits[0]!.extra as any)?.reply_markup?.inline_keyboard;
+    expect(keyboard[0].some((b: any) => b.text === "◀ Older")).toBe(true);
+    expect(keyboard[0].some((b: any) => b.text === "▶ Newer")).toBe(false);
+  });
+
+  it("returns toast when log file is missing", async () => {
+    const { ctx, callbackAnswers, edits } = makeCallbackCtx("sub_lg:nonexistent:0");
+    await handleCallback(ctx);
+
+    expect(callbackAnswers).toEqual(["Log file not found"]);
+    expect(edits).toHaveLength(0);
+  });
+});
+
 // Pinologs level-filtering integration tests removed — they pass in isolation
 // but fail in the full suite due to deep Bun mock.module() leaks that require
 // 3+ contaminating files to trigger.  The feature is simple, stable, and still

--- a/super_turtle/claude-telegram-bot/src/handlers/callback.ts
+++ b/super_turtle/claude-telegram-bot/src/handlers/callback.ts
@@ -43,6 +43,9 @@ import {
   readClaudeStateSummary,
   readClaudeBacklogItems,
   formatBacklogSummary,
+  handleSubturtle,
+  replySubturtleDetail,
+  parseCtlListOutput,
 } from "./commands";
 import { eventLog, streamLog } from "../logger";
 import { consumeHandledStopReply } from "./stop";
@@ -50,6 +53,8 @@ import { consumeHandledStopReply } from "./stop";
 const SAFE_CALLBACK_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 const SAFE_CALLBACK_OPTION_INDEX = /^\d+$/;
 const PINOLOG_LEVELS = new Set(["info", "warn", "error"]);
+const BACKLOG_PAGE_SIZE = 5;
+const LOG_LINES_PER_PAGE = 30;
 const callbackLog = streamLog.child({ handler: "callback" });
 
 function isSafeCallbackId(value: string): boolean {
@@ -334,7 +339,31 @@ export async function handleCallback(ctx: Context): Promise<void> {
     return;
   }
 
-  // 5. Handle subturtle stop callbacks: subturtle_stop:{name}
+  // 5a. Handle subturtle menu callback: sub_menu
+  if (callbackData === "sub_menu") {
+    await handleSubturtleMenuCallback(ctx);
+    return;
+  }
+
+  // 5b. Handle subturtle pick callback: sub_pick:{name}
+  if (callbackData.startsWith("sub_pick:")) {
+    await handleSubturtlePickCallback(ctx, callbackData);
+    return;
+  }
+
+  // 5c. Handle subturtle backlog pagination: sub_bl:{name}:{page}
+  if (callbackData.startsWith("sub_bl:")) {
+    await handleSubturtleBacklogPagination(ctx, callbackData);
+    return;
+  }
+
+  // 5b. Handle subturtle log pagination: sub_lg:{name}:{page}
+  if (callbackData.startsWith("sub_lg:")) {
+    await handleSubturtleLogPagination(ctx, callbackData);
+    return;
+  }
+
+  // 5c. Handle subturtle stop callbacks: subturtle_stop:{name}
   if (callbackData.startsWith("subturtle_stop:")) {
     await handleSubturtleStopCallback(ctx, callbackData);
     return;
@@ -546,11 +575,252 @@ async function handleSubturtleLogsCallback(
       }
     }
 
-    await ctx.reply(lines.join("\n"), { parse_mode: "HTML" });
+    await ctx.reply(lines.join("\n"), {
+      parse_mode: "HTML",
+      reply_markup: {
+        inline_keyboard: [[{ text: "↩ Menu", callback_data: "sub_menu" }]],
+      },
+    });
     await ctx.answerCallbackQuery({ text: `State for ${name}` });
   } catch (error) {
     callbackLog.error({ err: error, name, chatId: ctx.chat?.id }, "Failed to read SubTurtle state");
     await ctx.answerCallbackQuery({ text: "Failed to read state" });
+  }
+}
+
+/**
+ * Handle "↩ Menu" button — re-displays the /sub listing.
+ */
+async function handleSubturtleMenuCallback(ctx: Context): Promise<void> {
+  try {
+    await handleSubturtle(ctx);
+    await ctx.answerCallbackQuery();
+  } catch (error) {
+    callbackLog.error({ err: error, chatId: ctx.chat?.id }, "Failed to show SubTurtle menu");
+    await ctx.answerCallbackQuery({ text: "Failed to load menu" });
+  }
+}
+
+/**
+ * Handle sub_pick:{name} — user picked a SubTurtle from the selection list.
+ * Shows the 4 action buttons for that SubTurtle with a Menu button to go back.
+ */
+async function handleSubturtlePickCallback(
+  ctx: Context,
+  callbackData: string
+): Promise<void> {
+  const name = callbackData.replace("sub_pick:", "");
+
+  if (!name || !isSafeCallbackId(name)) {
+    await ctx.answerCallbackQuery({ text: "Invalid SubTurtle name" });
+    return;
+  }
+
+  try {
+    // Run ctl list to find the SubTurtle's current info
+    const proc = Bun.spawnSync([CTL_PATH, "list"], {
+      cwd: WORKING_DIR,
+      env: {
+        ...process.env,
+        SUPER_TURTLE_PROJECT_DIR: WORKING_DIR,
+        CLAUDE_WORKING_DIR: WORKING_DIR,
+      },
+    });
+    const turtles = parseCtlListOutput(proc.stdout.toString());
+    const turtle = turtles.find((t) => t.name === name);
+
+    if (!turtle) {
+      await ctx.answerCallbackQuery({ text: "SubTurtle not found" });
+      return;
+    }
+
+    await replySubturtleDetail(ctx, turtle, true);
+    await ctx.answerCallbackQuery();
+  } catch (error) {
+    callbackLog.error({ err: error, name, chatId: ctx.chat?.id }, "Failed to show SubTurtle detail");
+    await ctx.answerCallbackQuery({ text: "Failed to load SubTurtle" });
+  }
+}
+
+/**
+ * Parse pagination callback data in the format "prefix:name:page".
+ * Returns null if the name or page is invalid.
+ */
+function parsePaginationCallback(
+  callbackData: string,
+  prefix: string
+): { name: string; page: number } | null {
+  const rest = callbackData.slice(prefix.length);
+  const lastColon = rest.lastIndexOf(":");
+  if (lastColon === -1) return null;
+
+  const name = rest.slice(0, lastColon);
+  const pageStr = rest.slice(lastColon + 1);
+
+  if (!name || !isSafeCallbackId(name)) return null;
+  if (!/^\d+$/.test(pageStr)) return null;
+
+  const page = Number.parseInt(pageStr, 10);
+  if (!Number.isFinite(page) || page < 0 || page > 1000) return null;
+
+  return { name, page };
+}
+
+/**
+ * Handle paginated backlog view (sub_bl:{name}:{page}).
+ * Shows BACKLOG_PAGE_SIZE items per page with Prev/Next navigation.
+ */
+async function handleSubturtleBacklogPagination(
+  ctx: Context,
+  callbackData: string
+): Promise<void> {
+  const parsed = parsePaginationCallback(callbackData, "sub_bl:");
+  if (!parsed) {
+    await ctx.answerCallbackQuery({ text: "Invalid callback data" });
+    return;
+  }
+
+  const { name, page } = parsed;
+
+  try {
+    const statePath = `${WORKING_DIR}/.subturtles/${name}/CLAUDE.md`;
+    const [summary, backlog] = await Promise.all([
+      readClaudeStateSummary(statePath),
+      readClaudeBacklogItems(statePath),
+    ]);
+
+    if (!summary) {
+      await ctx.answerCallbackQuery({ text: "State file not found" });
+      return;
+    }
+
+    if (backlog.length === 0) {
+      await ctx.answerCallbackQuery({ text: "No backlog items" });
+      return;
+    }
+
+    const totalPages = Math.ceil(backlog.length / BACKLOG_PAGE_SIZE);
+    const safePage = Math.max(0, Math.min(page, totalPages - 1));
+    const start = safePage * BACKLOG_PAGE_SIZE;
+    const pageItems = backlog.slice(start, start + BACKLOG_PAGE_SIZE);
+    const doneCount = backlog.filter((item) => item.done).length;
+
+    const lines: string[] = [
+      `📝 <b>Backlog for ${escapeHtml(name)}</b>`,
+      `${doneCount}/${backlog.length} done — page ${safePage + 1}/${totalPages}`,
+      "",
+    ];
+
+    for (let i = 0; i < pageItems.length; i++) {
+      const item = pageItems[i]!;
+      const status = item.done ? "✅" : "⬜";
+      const currentTag = item.current ? " ← current" : "";
+      const idx = start + i + 1;
+      lines.push(`${idx}. ${status} ${convertMarkdownToHtml(item.text)}${currentTag}`);
+    }
+
+    const navButtons: Array<{ text: string; callback_data: string }> = [];
+    if (safePage > 0) {
+      navButtons.push({ text: "◀ Prev", callback_data: `sub_bl:${name}:${safePage - 1}` });
+    }
+    if (safePage < totalPages - 1) {
+      navButtons.push({ text: "▶ Next", callback_data: `sub_bl:${name}:${safePage + 1}` });
+    }
+
+    const keyboard: Array<Array<{ text: string; callback_data: string }>> = [];
+    if (navButtons.length > 0) {
+      keyboard.push(navButtons);
+    }
+    keyboard.push([{ text: "↩ Menu", callback_data: "sub_menu" }]);
+
+    await ctx.editMessageText(lines.join("\n"), {
+      parse_mode: "HTML",
+      reply_markup: { inline_keyboard: keyboard },
+    });
+    await ctx.answerCallbackQuery();
+  } catch (error) {
+    callbackLog.error({ err: error, name, chatId: ctx.chat?.id }, "Failed to read SubTurtle backlog");
+    await ctx.answerCallbackQuery({ text: "Failed to read backlog" });
+  }
+}
+
+/**
+ * Handle paginated log view (sub_lg:{name}:{page}).
+ * Page 0 = most recent lines, higher pages = older lines.
+ */
+async function handleSubturtleLogPagination(
+  ctx: Context,
+  callbackData: string
+): Promise<void> {
+  const parsed = parsePaginationCallback(callbackData, "sub_lg:");
+  if (!parsed) {
+    await ctx.answerCallbackQuery({ text: "Invalid callback data" });
+    return;
+  }
+
+  const { name, page } = parsed;
+
+  try {
+    const logPath = `${WORKING_DIR}/.subturtles/${name}/subturtle.log`;
+    const logFile = Bun.file(logPath);
+    const exists = await logFile.exists();
+
+    if (!exists) {
+      await ctx.answerCallbackQuery({ text: "Log file not found" });
+      return;
+    }
+
+    const content = await logFile.text();
+    const allLines = content.split("\n").filter((line) => line.trim().length > 0);
+
+    if (allLines.length === 0) {
+      await ctx.answerCallbackQuery({ text: "Log file is empty" });
+      return;
+    }
+
+    // Reverse so page 0 = newest lines
+    const reversed = [...allLines].reverse();
+    const totalPages = Math.ceil(reversed.length / LOG_LINES_PER_PAGE);
+    const safePage = Math.max(0, Math.min(page, totalPages - 1));
+    const start = safePage * LOG_LINES_PER_PAGE;
+    const pageLines = reversed.slice(start, start + LOG_LINES_PER_PAGE);
+
+    // Re-reverse so lines read top-to-bottom in chronological order
+    pageLines.reverse();
+
+    const header = `📜 <b>Logs for ${escapeHtml(name)}</b> — page ${safePage + 1}/${totalPages}\n`;
+    const logText = pageLines.map((l) => escapeHtml(l)).join("\n");
+
+    // Truncate if needed to stay under Telegram's limit
+    const maxLogLength = 4000 - header.length - 100;
+    const truncatedLog = logText.length > maxLogLength
+      ? logText.slice(0, maxLogLength) + "\n..."
+      : logText;
+
+    const body = `${header}<pre>${truncatedLog}</pre>`;
+
+    const navButtons: Array<{ text: string; callback_data: string }> = [];
+    if (safePage < totalPages - 1) {
+      navButtons.push({ text: "◀ Older", callback_data: `sub_lg:${name}:${safePage + 1}` });
+    }
+    if (safePage > 0) {
+      navButtons.push({ text: "▶ Newer", callback_data: `sub_lg:${name}:${safePage - 1}` });
+    }
+
+    const keyboard: Array<Array<{ text: string; callback_data: string }>> = [];
+    if (navButtons.length > 0) {
+      keyboard.push(navButtons);
+    }
+    keyboard.push([{ text: "↩ Menu", callback_data: "sub_menu" }]);
+
+    await ctx.editMessageText(body, {
+      parse_mode: "HTML",
+      reply_markup: { inline_keyboard: keyboard },
+    });
+    await ctx.answerCallbackQuery();
+  } catch (error) {
+    callbackLog.error({ err: error, name, chatId: ctx.chat?.id }, "Failed to read SubTurtle logs");
+    await ctx.answerCallbackQuery({ text: "Failed to read logs" });
   }
 }
 

--- a/super_turtle/claude-telegram-bot/src/handlers/commands.ts
+++ b/super_turtle/claude-telegram-bot/src/handlers/commands.ts
@@ -1791,6 +1791,10 @@ export async function handleSubturtle(ctx: Context): Promise<void> {
     return;
   }
 
+  // Check if a specific SubTurtle name was given (e.g. "/sub texting-page")
+  const messageText = ctx.message?.text || "";
+  const argName = messageText.split(/\s+/).slice(1).join(" ").trim();
+
   // Run ctl list command
   const ctlPath = CTL_PATH;
   const proc = Bun.spawnSync([ctlPath, "list"], {
@@ -1814,6 +1818,19 @@ export async function handleSubturtle(ctx: Context): Promise<void> {
     await ctx.reply("📋 <b>SubTurtles</b>\n\nNo SubTurtles found", { parse_mode: "HTML" });
     return;
   }
+
+  // If a specific name was given, show that SubTurtle's detail view directly
+  if (argName) {
+    const match = turtles.find((t) => t.name === argName);
+    if (!match) {
+      await ctx.reply(`❌ SubTurtle <b>${escapeHtml(argName)}</b> not found`, { parse_mode: "HTML" });
+      return;
+    }
+    await replySubturtleDetail(ctx, match, false);
+    return;
+  }
+
+  const runningTurtles = turtles.filter((t) => t.status === "running");
 
   const rootStatePath = `${WORKING_DIR}/CLAUDE.md`;
   const [rootSummary, turtleStateEntries] = await Promise.all([
@@ -1843,7 +1860,6 @@ export async function handleSubturtle(ctx: Context): Promise<void> {
   for (const turtle of turtles) {
     const stateSummary = turtleStateMap.get(turtle.name) || null;
 
-    // Format the turtle info line
     let statusEmoji = turtle.status === "running" ? "🟢" : "⚫";
     let timeStr = "";
     if (turtle.timeRemaining) {
@@ -1865,27 +1881,91 @@ export async function handleSubturtle(ctx: Context): Promise<void> {
       messageLines.push(`   📌 ${convertMarkdownToHtml(truncateText(backlogSummary, 140))}`);
     }
 
-    // Add buttons for running turtles
-    if (turtle.status === "running") {
-      keyboard.push([
-        {
-          text: "📋 State",
-          callback_data: `subturtle_logs:${turtle.name}`,
-        },
-        {
-          text: "🛑 Stop",
-          callback_data: `subturtle_stop:${turtle.name}`,
-        },
-      ]);
-    }
     if (turtle.tunnelUrl) {
       messageLines.push(`   🔗 ${escapeHtml(turtle.tunnelUrl)}`);
+    }
+  }
+
+  // 1 running SubTurtle → show 4 action buttons directly
+  // 2+ running → show name-selection buttons so user picks one first
+  if (runningTurtles.length === 1) {
+    const name = runningTurtles[0]!.name;
+    keyboard.push([
+      { text: "📋 State", callback_data: `subturtle_logs:${name}` },
+      { text: "🛑 Stop", callback_data: `subturtle_stop:${name}` },
+    ]);
+    keyboard.push([
+      { text: "📝 Backlog", callback_data: `sub_bl:${name}:0` },
+      { text: "📜 Logs", callback_data: `sub_lg:${name}:0` },
+    ]);
+  } else if (runningTurtles.length > 1) {
+    for (const turtle of runningTurtles) {
+      keyboard.push([
+        { text: `🐢 ${turtle.name}`, callback_data: `sub_pick:${turtle.name}` },
+      ]);
     }
   }
 
   await ctx.reply(messageLines.join("\n"), {
     parse_mode: "HTML",
     reply_markup: keyboard.length > 0 ? { inline_keyboard: keyboard } : undefined,
+  });
+}
+
+/**
+ * Show a single SubTurtle's detail view with action buttons.
+ * Used by /sub <name> and sub_pick:{name} callback.
+ * showMenu: whether to show the "↩ Menu" button (true when picking from multiple).
+ */
+export async function replySubturtleDetail(
+  ctx: Context,
+  turtle: ListedSubTurtle,
+  showMenu: boolean
+): Promise<void> {
+  const statePath = `${WORKING_DIR}/.subturtles/${turtle.name}/CLAUDE.md`;
+  const summary = await readClaudeStateSummary(statePath);
+
+  const statusEmoji = turtle.status === "running" ? "🟢" : "⚫";
+  let timeStr = "";
+  if (turtle.timeRemaining) {
+    const suffix = turtle.timeRemaining === "OVERDUE" || turtle.timeRemaining === "no timeout"
+      ? ""
+      : " left";
+    timeStr = ` • ${turtle.timeRemaining}${suffix}`;
+  }
+
+  const taskSource = summary?.currentTask || turtle.task || "No current task";
+  const lines: string[] = [
+    `${statusEmoji} <b>${escapeHtml(turtle.name)}</b>${escapeHtml(timeStr)}`,
+    `🧩 ${convertMarkdownToHtml(taskSource)}`,
+  ];
+
+  if (summary) {
+    lines.push(`📌 ${convertMarkdownToHtml(formatBacklogSummary(summary))}`);
+  }
+
+  if (turtle.tunnelUrl) {
+    lines.push(`🔗 ${escapeHtml(turtle.tunnelUrl)}`);
+  }
+
+  const keyboard: Array<Array<{ text: string; callback_data: string }>> = [
+    [
+      { text: "📋 State", callback_data: `subturtle_logs:${turtle.name}` },
+      { text: "🛑 Stop", callback_data: `subturtle_stop:${turtle.name}` },
+    ],
+    [
+      { text: "📝 Backlog", callback_data: `sub_bl:${turtle.name}:0` },
+      { text: "📜 Logs", callback_data: `sub_lg:${turtle.name}:0` },
+    ],
+  ];
+
+  if (showMenu) {
+    keyboard.push([{ text: "↩ Menu", callback_data: "sub_menu" }]);
+  }
+
+  await ctx.reply(lines.join("\n"), {
+    parse_mode: "HTML",
+    reply_markup: { inline_keyboard: keyboard },
   });
 }
 


### PR DESCRIPTION
## Summary

Closes #7

- **Backlog pagination:** New 📝 Backlog button on `/sub` shows checklist items 5 per page with ◀ Prev / ▶ Next navigation, done count, and current item highlighting
- **Log pagination:** New 📜 Logs button shows SubTurtle log output 30 lines per page with ◀ Older / ▶ Newer navigation
- **Smart button layout:** When 1 SubTurtle is running, action buttons show directly; when 2+ are running, name-selection buttons appear first so you know which SubTurtle each button controls
- **Direct access:** `/sub <name>` jumps straight to a specific SubTurtle's detail view
- **Navigation:** ↩ Menu button on all detail views to return to the SubTurtle list
- **Security:** Page number cap to prevent abuse via crafted callback data

## Test plan

- [x] Automated tests pass (8/8) for backlog pagination, log pagination, and edge cases
- [x] TypeScript typecheck passes
- [x] Manual testing in Telegram confirmed working: backlog pages, log pages, menu navigation, multi-SubTurtle selection